### PR TITLE
Add TWZRD Agent Intel — Solana x402 trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ If you find this helpful, please give us a Star!
 
 - [AI Developer Tools](#ai-developer-tools)
   - [AI Coding Assistants](#ai-coding-assistants)
+- **[TWZRD Agent Intel](https://intel.twzrd.xyz)** - Solana-native x402 MCP server for AI agent trust scoring. Free tools: `score_agent(wallet)`, `preflight_check(wallet)`. Paid: `get_trust_receipt` via HTTP 402 + USDC on Solana. MCP: `https://intel.twzrd.xyz/mcp`
   - [AI Code Review Tools](#ai-code-review-tools)
   - [AI SQL Tools](#ai-sql-tools)
   - [AI ReGex Tools](#ai-regex-tools)


### PR DESCRIPTION
## Summary

Adds **[TWZRD Agent Intel](https://intel.twzrd.xyz)** — a Solana-native x402 trust scoring MCP server for AI agents.

- **MCP endpoint**: streamable-HTTP at `https://intel.twzrd.xyz/mcp` (zero install, no npm)
- **Free tools**: `score_agent(wallet)`, `preflight_check(wallet)` — Solana wallet trust scores
- **Paid tool**: `get_trust_receipt(wallet)` — signed trust receipt via HTTP 402 + USDC micropayment on Solana
- **Config**: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`